### PR TITLE
Fix lambda syntax for Python 3 compatability

### DIFF
--- a/src/handeye/calibrator.py
+++ b/src/handeye/calibrator.py
@@ -54,7 +54,7 @@ class HandEyeCalibrator(object):
       raise TypeError('Invalid setup type: {}'.format(type(setup)))
     self.reset()
     self.min_samples_required = 4
-    self.valid_cos = lambda (x): np.clip(x, -1., 1.)
+    self.valid_cos = lambda x: np.clip(x, -1., 1.)
 
   def add_sample(self, Q, Pinv):
     """


### PR DESCRIPTION
This small change is all that was needed to run this package in Python 3, and it doesn't break Python 2. (Also, a noetic release would be great!)